### PR TITLE
Fix: 처리 못한 예외상황 처리

### DIFF
--- a/src/tokenizer.js
+++ b/src/tokenizer.js
@@ -1,26 +1,44 @@
 export default class Tokenizer {
   constructor() {
     this.result = [];
+    this.strStarted = false;
     this.acc = '';
     this.separatorArr = ["{", "}", "[", "]", ":", ","];
   }
-
   getTokens(input) {
-    const strArr = input.split("").filter(v => v !== " ")
+    const strArr = input.split("");
     strArr.forEach(str => this.tokenize(str));
-    this.result = this.result.filter(v => v !== ',');
+    this.result = this.result
+      .filter(v => v !== ',')
+      .filter(v => v !== ' ')
+      .map(str => str.trim());
     return this.result;
-  }
-
-  tokenize(str) {
-    const separator = this.separatorArr.find(v => str === v);
-    if(separator !== undefined) {
-        if(this.acc.length > 0) {
-            this.result.push(this.acc)
-            this.acc = '';
-        }
+  } 
+  tokenize(str) { 
+    if(this.isStrSeperator(str) || this.strStarted) this.accumulateStr(str);
+    else {
+      const separator = this.separatorArr.find(v => str === v);
+      if(separator !== undefined) {
+        if(this.acc.length > 0) this.pushNinitAcc();
         this.result.push(separator);
+      }
+      else this.acc += str;
     }
-    else this.acc += str;
+  }
+  isStrSeperator(str) {
+    return str === '\"' || str === '\'';
+  }
+  pushNinitAcc() {
+    this.result.push(this.acc)
+    this.acc = '';
+  }
+  accumulateStr(str) {
+    this.acc += str;
+    if(!this.strStarted && this.isStrSeperator(str)) this.strStarted = true;
+    else if(this.strStarted && this.isStrSeperator(str)) {
+      this.strStarted = false;
+      this.result.push(this.acc)
+      this.acc = '';
+    }
   }
 }


### PR DESCRIPTION
* 문자열 내부 띄어쓰기를 모두 없애버려서 공백은 마지막에 없어지도록 수정
* 문자열 내부에 seperator가 있을 때 문자열을 쪼개버리는 예외상황이 발생
* 문자열 따옴표 시작 시에는 끝날 때까지 acc에 담도록 수정